### PR TITLE
ci: build dev image on PRs to validate Dockerfile changes

### DIFF
--- a/.github/workflows/build-dev-image.yml
+++ b/.github/workflows/build-dev-image.yml
@@ -7,6 +7,13 @@ on:
       - 'mise.toml'
       - 'scripts/install-*'
       - '.github/workflows/build-dev-image.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - '.devcontainer/**'
+      - 'mise.toml'
+      - 'scripts/install-*'
+      - '.github/workflows/build-dev-image.yml'
   workflow_dispatch:
 
 permissions:
@@ -21,6 +28,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -32,7 +40,7 @@ jobs:
         with:
           context: .
           file: .devcontainer/Dockerfile
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: |
             ghcr.io/ptsouchlos/modern-cv-dev:latest
             ghcr.io/ptsouchlos/modern-cv-dev:${{ github.sha }}


### PR DESCRIPTION
## Changes
- Adds a `pull_request` trigger to `build-dev-image.yml` (same path filters as the existing `push` trigger) so Dockerfile/mise.toml/install-script changes get build-validated before merge.
- On `pull_request` events the image is built but not pushed to packages repo
